### PR TITLE
Introduce Oracle Universal Connection Pool

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -46,6 +46,7 @@ dependencies {
   runtimeOnly group: 'com.oracle.database.jdbc', name: 'ojdbc8', version: '21.1.0.0'
   // https://mvnrepository.com/artifact/com.oracle.ojdbc/orai18n
   runtimeOnly group: 'com.oracle.database.nls', name: 'orai18n', version: '21.1.0.0'
+  implementation group: 'com.oracle.database.jdbc', name: 'ucp', version: '21.1.0.0'
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.0.0") // for IDE

--- a/src/src/main/java/com/example/nedo/db/DBUtils.java
+++ b/src/src/main/java/com/example/nedo/db/DBUtils.java
@@ -11,6 +11,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+
 import org.postgresql.util.PSQLException;
 
 import com.example.nedo.app.Config;
@@ -27,7 +30,17 @@ public class DBUtils {
 	public static Connection getConnection(Config config) {
         Connection conn;
 		try {
-			conn = DriverManager.getConnection(config.url, config.user, config.password);
+			if (config.url.startsWith("jdbc:oracle")) {
+				PoolDataSource pds = PoolDataSourceFactory.getPoolDataSource();
+				pds.setConnectionFactoryClassName("oracle.jdbc.pool.OracleDataSource");
+				pds.setURL(config.url);
+				pds.setUser(config.user);
+				pds.setPassword(config.password);
+				pds.setMaxStatements(256);
+				conn = pds.getConnection();
+			} else {
+				conn = DriverManager.getConnection(config.url, config.user, config.password);
+			}
 			conn.setAutoCommit(false);
 			conn.setTransactionIsolation(config.isolationLevel);
 		} catch (SQLException e) {


### PR DESCRIPTION
Oracle上での実行時にUCP(Universal Connection Pool)を経由したPrepared Statement Cacheを利用することでパフォーマンスを向上させます。

この方法は原価計算ベンチマークの評価時に調査して効果があったもので、実装もこれをベースにしています。
PostgreSQLのJDBCドライバには標準でPrepared Statement Cacheの機能が含まれており、Oracle上でも同様の仕組みを導入することでパフォーマンスを向上させること、およびDBMS間の比較評価時になるべく前提条件を近づけることを目的とします。

また、本Pull Requestでは合わせてJDBCドライバのバージョンアップを行っていますが、
これは原価計算ベンチマークの評価で実績のあったバージョンに合わせるためです。
JDBCドライバのバージョンアップによる性能の大きな変化はないことを確認済みです。

以下、10万レコードでのパッチ前後(UCP適用前、適用後)のベンチマークです。
ケースによって効果にばらつきがありますが、全ケースで高速になっています。

### UCP適用前
| PhoneBill:records=100000   |  CONTRACT  |    WHOLE   |
| -------------------------- | ---------- | ---------- |
| thread=1                   |   171.413  |    61.663  |
| thread=10 READ_COMMITTED   |    32.709  |    13.191  |
| thread=10 SERIALIZABLE     |   114.666  |     N/A    |

### UCP適用後
| PhoneBill:records=100000   |  CONTRACT  |    WHOLE   |
| -------------------------- | ---------- | ---------- |
| thread=1                   |   144.148  |    40.525  |
| thread=10 READ_COMMITTED   |    31.732  |    12.154  |
| thread=10 SERIALIZABLE     |    92.130  |     N/A    |
