### PR TITLE
Add fdw.name to template config file

### DIFF
--- a/scripts/etc/phone-bill.ini.template
+++ b/scripts/etc/phone-bill.ini.template
@@ -13,3 +13,6 @@
 [ipc_endpoint]
     database_name=phone-bill
     threads=80
+
+[fdw]
+    name=phone-bill


### PR DESCRIPTION
fdw.nameが未指定だと他のTsurugiプロセスと名前が衝突してしまうのでIPCに合わせた名前を指定するように変更しました。