### PR TITLE
Separate detail logfile for online apps

### DIFF
--- a/scripts/etc/logback.xml
+++ b/scripts/etc/logback.xml
@@ -10,6 +10,25 @@
     </encoder>
   </appender>
 
+  <appender name="DETAIL-ONLINE"
+    class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${log.detail.online}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${log.detail.online}_%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>2</maxIndex>
+    </rollingPolicy>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>1MB</maxFileSize>
+    </triggeringPolicy>
+    <append>true</append>
+    <encoder>
+      <pattern>
+        %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+     </pattern>
+    </encoder>
+  </appender>
+
   <appender name="SUMMARY"
     class="ch.qos.logback.core.FileAppender">
     <file>${log.summary}</file>
@@ -35,6 +54,15 @@
     <level>ERROR</level>
     </filter>
   </appender>
+
+  <logger name="com.tsurugidb.benchmark.phonebill.online" level="info">
+    <appender-ref ref="SUMMARY" />
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <logger name="com.tsurugidb.benchmark.phonebill.online" level="debug" additivity="false">
+    <appender-ref ref="DETAIL-ONLINE" />
+  </logger>
 
   <root level="DETAIL">
     <appender-ref ref="SUMMARY" />

--- a/scripts/multiple_execute.sh
+++ b/scripts/multiple_execute.sh
@@ -19,10 +19,12 @@ export DB_INIT_CMD=$BIN_DIR/tinit.sh
 export JAVA_OPTS="$JAVA_OPTS -Dcom.tsurugidb.tsubakuro.jniverify=false \
  -Dlogback.configurationFile=$BIN_DIR/etc/logback.xml \
  -Dlog.summary=$LOG_DIR/summary-$ext \
- -Dlog.detail=$LOG_DIR/detail-$ext"
+ -Dlog.detail=$LOG_DIR/detail-$ext \
+ -Dlog.detail.online=$LOG_DIR/detail-online-$ext"
 
 ln -sf $LOG_DIR/summary-$ext $LOG_DIR/summary.log
 ln -sf $LOG_DIR/detail-$ext $LOG_DIR/detail.log
+ln -sf $LOG_DIR/detail-online-$ext $LOG_DIR/detail-online.log
 
 $INSTALL_DIR/phone-bill/bin/run MultipleExecute "$@"
 


### PR DESCRIPTION
CB環境上でオンラインアプリが出すDETAILログが肥大化するため、logbackの設定でオンラインアプリが出すDETAILログのみを別ファイルにして、オンライン側のDETAILログはRollingFileAppenderを使ってファイルサイズを制限するよう変更します。
以下仕様です。
- `com.tsurugidb.benchmark.phonebill.online` 配下のパッケージ内のクラスが出力する、 `DEBUG` 以上のログレベルのログを別ファイルに出力
- ファイル名は `detail-online-xxx.log`
- このファイルは各ファイル1MBのサイズ制限で3世代保持する。

サイズローテーションを行うことによって古いERRORログなどは `detail-online-xxx.log` から確認することはできない可能性もあるが、該当パッケージに対してINFO以上のログレベルのログはこれまで同様 `SUMMARY` , `STDOUT` Appenderにつなげることで、これらのAppender経由でログが出力されるように対応している。
このためERRORログなどの重要な情報はsummaryログや標準出力で確認することが可能。
