### PR TITLE
build: introduce Gradle Toolchain Resolver Plugin

### DIFF
--- a/src/settings.gradle
+++ b/src/settings.gradle
@@ -15,4 +15,8 @@ include 'api'
 include 'services:webservice'
 */
 
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = 'phone-bill'


### PR DESCRIPTION
Introduce Toolchain Resolver Plugin for enabling Java toolchain auto-provisioning feature.